### PR TITLE
User displayname set when create user

### DIFF
--- a/core/authors/models.py
+++ b/core/authors/models.py
@@ -26,7 +26,7 @@ class Author(models.Model):
         return self.displayName
 
     def __str__(self):
-        return self.user.email
+        return self.user.username
 
 class Follow(models.Model):
     follower = models.URLField()
@@ -55,3 +55,5 @@ def create_author_profile(sender, instance, created, **kwargs):
     """
     if created:
         author, new = Author.objects.get_or_create(user=instance)
+        author.displayName = instance.username
+        author.save()

--- a/core/authors/tests/test_friend_request_views.py
+++ b/core/authors/tests/test_friend_request_views.py
@@ -235,7 +235,7 @@ class PendingFriendRequestViewsTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
         self.assertEqual(response.data[0], {
-            'displayName': self.author2.get_display_name(),
+            'displayName': self.author1.get_display_name(),
             'id': author1Url,
             'host': author1Url.split("/author/")[0],
             'url': author1Url


### PR DESCRIPTION
Admin doesn't need to enter user's displayname to approve/save now.